### PR TITLE
Feature: Implement Strict Script Line Count Validation

### DIFF
--- a/podcast_generator.py
+++ b/podcast_generator.py
@@ -183,6 +183,10 @@ def main():
         convert_text_to_audio(text, voice_id, filename)
         audio_files.append(filename)
 
+    if len(dialogue) != 6:
+        raise ValueError("Parsed dialogue must contain exactly 6 lines (3 from host, 3 from guest).")
+
+
     print("🎧 Merging audio...")
     merge_audio_files(audio_files, args.output_audio_file)
 


### PR DESCRIPTION
Added a validation step to ensure that the podcast script contains exactly 6 dialogue lines (3 from HOST and 3 from GUEST).
This prevents unexpected script formats and ensures audio generation stays on track.